### PR TITLE
Allow combination counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,19 +41,36 @@ The resolutions API can now be accessed via the global variable
 ```javascript
 function getResolutionsCount(options)
 ```
-where `options` is of the form:
-```javascript
+which returns
+```
 {
-    fusiontable: optional string, // the ID of the google fusiontable
-    googleApiKey: required string, // the API key created in the
-        // Google developers console for the FDPA Resolutions project
-    statusSought: optional string, // -, inWork, materialsSent, passed, or
-        // refusedOrOther
-    successHandler: required function // called when a count is available
+   verified: boolean, true means the request was submitted
+   errorFields: array, lists fields that failed if verified is false
+   googleApiKey: options.googleApiKey or an error message
+   fusionTable: options.fusionTable or a sensible default
+   statusSought: an array of status strings derived from options.status,
+     or an error message
 }
 ```
-and the `successHandler` is defined by the caller to take one argument,
-where the argument is an integer representing the count.
+and where `options` is of the form:
+```javascript
+{
+   googleApiKey: required string,
+   fusiontable: optional string, defaults to the expected table
+   status: optional string, defaults to '-'
+   successHandler: optional function, defaults to an empty function
+}
+```
+and where:
+- googleApiKey is an API key created in the Google developers console
+  for the FDPA Resolutions project.
+- fusiontable is the ID of a Google fusiontable for the
+  FDPA Resolutions project.
+- status may be '-', 'inWork', 'materialsSent', 'passed',
+  'refusedOrOther', or a combination of these separated by a comma
+  and no space.
+- successHandler function has the prototype `function(count)`,
+  where `count` is an integer returned from the query.
 
 ## Build from Source
 

--- a/distribution/fusionApi.js
+++ b/distribution/fusionApi.js
@@ -74,6 +74,8 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
 /* jshint browser: true */
 /* jshint esversion: 6 */
 
+/*** public interface ***/
+
 var validStatus = {
     '-': '-',
     inWork: 'In work',
@@ -82,24 +84,80 @@ var validStatus = {
     refusedOrOther: 'Refused/other'
 };
 
+/*
+ * getResolutionsCount(options)
+ * returns {
+ *    verified: boolean, true means the request was submitted
+ *    errorFields: array, lists fields that failed if verified is false
+ *    googleApiKey: options.googleApiKey or an error message
+ *    fusionTable: options.fusionTable or a sensible default
+ *    statusSought: an array of status strings derived from options.status,
+ *      or an error message
+ * }
+ * options = {
+ *    googleApiKey: required string,
+ *    fusiontable: optional string, defaults to the expected table
+ *    status: optional string, defaults to '-'
+ *    successHandler: optional function, defaults to an empty function
+ * }
+ * where:
+ * - googleApiKey is an API key created in the Google developers console
+ *   for the FDPA Resolutions project.
+ * - fusiontable is the ID of a Google fusiontable for the
+ *   FDPA Resolutions project.
+ * - status may be '-', 'inWork', 'materialsSent', 'passed',
+ *   'refusedOrOther', or a combination of these separated by a comma
+ *   and no space.
+ * - successHandler function has the prototype `function(count)`,
+ *   where `count` is an integer returned from the query.
+ */
 function getResolutionsCount(options) {
-    var fusiontable = options.fusiontable ||
-        '10Uc_t_dBYUV_K_j6HdCMSgLXGs94bXvunQBGDOjF';
-    if (!options.googleApiKey) {
-        throw 'getting the resolutions count requires an API key';
+    var verification = verifyResolutionCountOptions(options);
+    if (verification.verified !== true) {
+        return verification;
     }
-    var googleApiKey = options.googleApiKey;
-    var statusSought = options.status || '-';
-    if (!(statusSought in validStatus)) {
-        throw 'can only get resolutions count for status of ' +
-            '-, inWork, materialsSent, passed, or refusedOrOther';
-    }
-    var successHandler = options.successHandler || function() {};
-    makeResolutionsCountRequest(statusSought, fusiontable, googleApiKey,
+    makeResolutionsCountRequest(verification.statusSought,
+            verification.fusiontable, verification.googleApiKey,
             function() {
                 var response = JSON.parse(this.responseText);
-                successHandler(response.rows[0][0]);
+                verification.successHandler(response.rows[0][0]);
             });
+    return verification;
+}
+
+/*** private support functions ***/
+
+function verifyResolutionCountOptions(options) {
+    var verification = {
+        verified: true,
+        errorFields: [],
+        fusiontable: options.fusiontable ||
+            '10Uc_t_dBYUV_K_j6HdCMSgLXGs94bXvunQBGDOjF',
+        googleApiKey: options.googleApiKey,
+        statusSought: options.status || '-',
+        successHandler: options.successHandler || function() {}
+    };
+    if (!options.googleApiKey) {
+        verification.googleApiKey = 'getting the resolutions count requires an API key';
+        verification.errorFields.push('googleApiKey');
+        verification.verified = false;
+    }
+    var invalidStrings = [];
+    verification.statusSought = verification.statusSought.split(',');
+    verification.statusSought.forEach(function(statusKey) {
+        if (!(statusKey in validStatus)) {
+            invalidStrings.push(statusKey);
+        }
+    });
+    if (0 < invalidStrings.length) {
+        verification.statusSought = invalidStrings.join(', ') +
+                'not among valid status keys of ' +
+                '-, inWork, materialsSent, passed, or refusedOrOther';
+        verification.errorFields.push('statusSought');
+        verification.verified = false;
+    }
+
+    return verification;
 }
 
 function makeResolutionsCountRequest(statusSought, fusiontable, googleApiKey,
@@ -109,13 +167,26 @@ function makeResolutionsCountRequest(statusSought, fusiontable, googleApiKey,
         '?' +
         'sql=' +
         'SELECT COUNT(Status) FROM ' + fusiontable +
-        " WHERE 'Status' IN '" + validStatus[statusSought] + "'" +
+        " WHERE 'Status' IN " + constructInCondition(statusSought) +
         '&' +
         'key=' + googleApiKey;
     request.addEventListener('load', successHandler);
     request.open('GET', encodeURI(uri));
     request.send();
 }
+
+function constructInCondition(statusArray) {
+    var quoted = statusArray.map(function(statusSought) {
+        return "'" + validStatus[statusSought] + "'";
+    });
+    if (1 === quoted.length) {
+        return quoted[0];
+    } else {
+        return '(' + quoted.join(',') + ')';
+    }
+}
+
+/*** ES6 export ***/
 
 /* harmony default export */ __webpack_exports__["default"] = ({
     'getResolutionsCount': getResolutionsCount

--- a/distribution/fusionApi_es5.js
+++ b/distribution/fusionApi_es5.js
@@ -89,6 +89,8 @@ window.fdpaResolutions = __WEBPACK_IMPORTED_MODULE_0_fdpa_fusionApi_js__["a" /* 
 /* jshint browser: true */
 /* jshint esversion: 6 */
 
+/*** public interface ***/
+
 var validStatus = {
     '-': '-',
     inWork: 'In work',
@@ -97,24 +99,80 @@ var validStatus = {
     refusedOrOther: 'Refused/other'
 };
 
+/*
+ * getResolutionsCount(options)
+ * returns {
+ *    verified: boolean, true means the request was submitted
+ *    errorFields: array, lists fields that failed if verified is false
+ *    googleApiKey: options.googleApiKey or an error message
+ *    fusionTable: options.fusionTable or a sensible default
+ *    statusSought: an array of status strings derived from options.status,
+ *      or an error message
+ * }
+ * options = {
+ *    googleApiKey: required string,
+ *    fusiontable: optional string, defaults to the expected table
+ *    status: optional string, defaults to '-'
+ *    successHandler: optional function, defaults to an empty function
+ * }
+ * where:
+ * - googleApiKey is an API key created in the Google developers console
+ *   for the FDPA Resolutions project.
+ * - fusiontable is the ID of a Google fusiontable for the
+ *   FDPA Resolutions project.
+ * - status may be '-', 'inWork', 'materialsSent', 'passed',
+ *   'refusedOrOther', or a combination of these separated by a comma
+ *   and no space.
+ * - successHandler function has the prototype `function(count)`,
+ *   where `count` is an integer returned from the query.
+ */
 function getResolutionsCount(options) {
-    var fusiontable = options.fusiontable ||
-        '10Uc_t_dBYUV_K_j6HdCMSgLXGs94bXvunQBGDOjF';
-    if (!options.googleApiKey) {
-        throw 'getting the resolutions count requires an API key';
+    var verification = verifyResolutionCountOptions(options);
+    if (verification.verified !== true) {
+        return verification;
     }
-    var googleApiKey = options.googleApiKey;
-    var statusSought = options.status || '-';
-    if (!(statusSought in validStatus)) {
-        throw 'can only get resolutions count for status of ' +
-            '-, inWork, materialsSent, passed, or refusedOrOther';
-    }
-    var successHandler = options.successHandler || function() {};
-    makeResolutionsCountRequest(statusSought, fusiontable, googleApiKey,
+    makeResolutionsCountRequest(verification.statusSought,
+            verification.fusiontable, verification.googleApiKey,
             function() {
                 var response = JSON.parse(this.responseText);
-                successHandler(response.rows[0][0]);
+                verification.successHandler(response.rows[0][0]);
             });
+    return verification;
+}
+
+/*** private support functions ***/
+
+function verifyResolutionCountOptions(options) {
+    var verification = {
+        verified: true,
+        errorFields: [],
+        fusiontable: options.fusiontable ||
+            '10Uc_t_dBYUV_K_j6HdCMSgLXGs94bXvunQBGDOjF',
+        googleApiKey: options.googleApiKey,
+        statusSought: options.status || '-',
+        successHandler: options.successHandler || function() {}
+    };
+    if (!options.googleApiKey) {
+        verification.googleApiKey = 'getting the resolutions count requires an API key';
+        verification.errorFields.push('googleApiKey');
+        verification.verified = false;
+    }
+    var invalidStrings = [];
+    verification.statusSought = verification.statusSought.split(',');
+    verification.statusSought.forEach(function(statusKey) {
+        if (!(statusKey in validStatus)) {
+            invalidStrings.push(statusKey);
+        }
+    });
+    if (0 < invalidStrings.length) {
+        verification.statusSought = invalidStrings.join(', ') +
+                'not among valid status keys of ' +
+                '-, inWork, materialsSent, passed, or refusedOrOther';
+        verification.errorFields.push('statusSought');
+        verification.verified = false;
+    }
+
+    return verification;
 }
 
 function makeResolutionsCountRequest(statusSought, fusiontable, googleApiKey,
@@ -124,13 +182,26 @@ function makeResolutionsCountRequest(statusSought, fusiontable, googleApiKey,
         '?' +
         'sql=' +
         'SELECT COUNT(Status) FROM ' + fusiontable +
-        " WHERE 'Status' IN '" + validStatus[statusSought] + "'" +
+        " WHERE 'Status' IN " + constructInCondition(statusSought) +
         '&' +
         'key=' + googleApiKey;
     request.addEventListener('load', successHandler);
     request.open('GET', encodeURI(uri));
     request.send();
 }
+
+function constructInCondition(statusArray) {
+    var quoted = statusArray.map(function(statusSought) {
+        return "'" + validStatus[statusSought] + "'";
+    });
+    if (1 === quoted.length) {
+        return quoted[0];
+    } else {
+        return '(' + quoted.join(',') + ')';
+    }
+}
+
+/*** ES6 export ***/
 
 /* harmony default export */ __webpack_exports__["a"] = ({
     'getResolutionsCount': getResolutionsCount

--- a/harness/app.js
+++ b/harness/app.js
@@ -4,7 +4,7 @@
 
 import fdpaResolutions from 'fdpa/fusionApi.js';
 
-['passed', 'inWork'].forEach(function(statusSought) {
+['passed', 'inWork', 'inWork,materialsSent'].forEach(function(statusSought) {
     fdpaResolutions.getResolutionsCount({
         status: statusSought,
         fusiontable: '10Uc_t_dBYUV_K_j6HdCMSgLXGs94bXvunQBGDOjF',

--- a/harness/index.html
+++ b/harness/index.html
@@ -7,6 +7,7 @@
     <body>
         <p><span data-status="passed">_</span> passed resolutions</p>
         <p><span data-status="inWork">_</span> in work resolutions</p>
+        <p><span data-status="inWork,materialsSent">_</span> in work or materials sent resolutions</p>
 
         <script src="./dist/bundle.js"></script>
     </body>

--- a/src/js/fusionApi.js
+++ b/src/js/fusionApi.js
@@ -2,6 +2,8 @@
 /* jshint browser: true */
 /* jshint esversion: 6 */
 
+/*** public interface ***/
+
 var validStatus = {
     '-': '-',
     inWork: 'In work',
@@ -10,24 +12,80 @@ var validStatus = {
     refusedOrOther: 'Refused/other'
 };
 
+/*
+ * getResolutionsCount(options)
+ * returns {
+ *    verified: boolean, true means the request was submitted
+ *    errorFields: array, lists fields that failed if verified is false
+ *    googleApiKey: options.googleApiKey or an error message
+ *    fusionTable: options.fusionTable or a sensible default
+ *    statusSought: an array of status strings derived from options.status,
+ *      or an error message
+ * }
+ * options = {
+ *    googleApiKey: required string,
+ *    fusiontable: optional string, defaults to the expected table
+ *    status: optional string, defaults to '-'
+ *    successHandler: optional function, defaults to an empty function
+ * }
+ * where:
+ * - googleApiKey is an API key created in the Google developers console
+ *   for the FDPA Resolutions project.
+ * - fusiontable is the ID of a Google fusiontable for the
+ *   FDPA Resolutions project.
+ * - status may be '-', 'inWork', 'materialsSent', 'passed',
+ *   'refusedOrOther', or a combination of these separated by a comma
+ *   and no space.
+ * - successHandler function has the prototype `function(count)`,
+ *   where `count` is an integer returned from the query.
+ */
 function getResolutionsCount(options) {
-    var fusiontable = options.fusiontable ||
-        '10Uc_t_dBYUV_K_j6HdCMSgLXGs94bXvunQBGDOjF';
-    if (!options.googleApiKey) {
-        throw 'getting the resolutions count requires an API key';
+    var verification = verifyResolutionCountOptions(options);
+    if (verification.verified !== true) {
+        return verification;
     }
-    var googleApiKey = options.googleApiKey;
-    var statusSought = options.status || '-';
-    if (!(statusSought in validStatus)) {
-        throw 'can only get resolutions count for status of ' +
-            '-, inWork, materialsSent, passed, or refusedOrOther';
-    }
-    var successHandler = options.successHandler || function() {};
-    makeResolutionsCountRequest(statusSought, fusiontable, googleApiKey,
+    makeResolutionsCountRequest(verification.statusSought,
+            verification.fusiontable, verification.googleApiKey,
             function() {
                 var response = JSON.parse(this.responseText);
-                successHandler(response.rows[0][0]);
+                verification.successHandler(response.rows[0][0]);
             });
+    return verification;
+}
+
+/*** private support functions ***/
+
+function verifyResolutionCountOptions(options) {
+    var verification = {
+        verified: true,
+        errorFields: [],
+        fusiontable: options.fusiontable ||
+            '10Uc_t_dBYUV_K_j6HdCMSgLXGs94bXvunQBGDOjF',
+        googleApiKey: options.googleApiKey,
+        statusSought: options.status || '-',
+        successHandler: options.successHandler || function() {}
+    };
+    if (!options.googleApiKey) {
+        verification.googleApiKey = 'getting the resolutions count requires an API key';
+        verification.errorFields.push('googleApiKey');
+        verification.verified = false;
+    }
+    var invalidStrings = [];
+    verification.statusSought = verification.statusSought.split(',');
+    verification.statusSought.forEach(function(statusKey) {
+        if (!(statusKey in validStatus)) {
+            invalidStrings.push(statusKey);
+        }
+    });
+    if (0 < invalidStrings.length) {
+        verification.statusSought = invalidStrings.join(', ') +
+                'not among valid status keys of ' +
+                '-, inWork, materialsSent, passed, or refusedOrOther';
+        verification.errorFields.push('statusSought');
+        verification.verified = false;
+    }
+
+    return verification;
 }
 
 function makeResolutionsCountRequest(statusSought, fusiontable, googleApiKey,
@@ -37,13 +95,26 @@ function makeResolutionsCountRequest(statusSought, fusiontable, googleApiKey,
         '?' +
         'sql=' +
         'SELECT COUNT(Status) FROM ' + fusiontable +
-        " WHERE 'Status' IN '" + validStatus[statusSought] + "'" +
+        " WHERE 'Status' IN " + constructInCondition(statusSought) +
         '&' +
         'key=' + googleApiKey;
     request.addEventListener('load', successHandler);
     request.open('GET', encodeURI(uri));
     request.send();
 }
+
+function constructInCondition(statusArray) {
+    var quoted = statusArray.map(function(statusSought) {
+        return "'" + validStatus[statusSought] + "'";
+    });
+    if (1 === quoted.length) {
+        return quoted[0];
+    } else {
+        return '(' + quoted.join(',') + ')';
+    }
+}
+
+/*** ES6 export ***/
 
 export default {
     'getResolutionsCount': getResolutionsCount


### PR DESCRIPTION
Changes:
- Improved documentation
- `getResolutionsCount` `options.status` may now be a
  comma separated list of status keys,
  which all go into the sql query `WHERE ... IN` clause
- The test harness now tests a comma separated list